### PR TITLE
Update Docker Compose configuration and README for web interface access

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ docker compose up -d
 
 Сервисы будут доступны по следующим адресам:
 - API: `http://localhost:5055`
+- Web-интерфейс: `http://localhost:5066`
 - Prometheus: `http://localhost:8084`
 - Grafana: `http://localhost:8085` (логин: admin, пароль: admin)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     container_name: water-sensor-nginx
     restart: always
     ports:
-      - "80:80"
+      - "5066:80"
       - "8084:8084"
       - "8085:8085"
     volumes:


### PR DESCRIPTION
- Changed Nginx port mapping in docker-compose.yml from 80 to 5066.
- Updated README to include the new web interface URL at `http://localhost:5066`.